### PR TITLE
fix: #28 [BUG] Auto Equip Does Not Automatically Start Flight

### DIFF
--- a/src/main/java/net/elytraautopilot/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/net/elytraautopilot/mixin/ClientPlayerEntityMixin.java
@@ -4,6 +4,7 @@ import net.elytraautopilot.config.ModConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket;
 import net.minecraft.world.effect.MobEffects;
 import net.elytraautopilot.ElytraAutoPilot;
 import org.spongepowered.asm.mixin.Mixin;
@@ -29,6 +30,10 @@ public class ClientPlayerEntityMixin {
         if (canGlide(player)) { //&&
             // [Future] Replace with an event that fires before elytra take off.
             equipElytra(player);
+            // Set client-side flying flag AND send packet to server
+            // (Player.startFallFlying only sets the client flag, does NOT send the packet)
+            player.startFallFlying();
+            player.connection.send(new ServerboundPlayerCommandPacket(player, ServerboundPlayerCommandPacket.Action.START_FALL_FLYING));
         }
     }
 

--- a/src/main/java/net/elytraautopilot/utils/ElytraManager.java
+++ b/src/main/java/net/elytraautopilot/utils/ElytraManager.java
@@ -4,7 +4,6 @@ import net.elytraautopilot.config.ModConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -32,8 +31,6 @@ public class ElytraManager {
             lastUID = getItemUID(stack);
             swapChestplateSlot(elytraIndex, player);
             autoSwapIsActive = true;
-            // Send packet so server knows player is flying
-            player.connection.send(new ServerboundPlayerCommandPacket(player, ServerboundPlayerCommandPacket.Action.START_FALL_FLYING));
             return true;
         }
 
@@ -62,7 +59,6 @@ public class ElytraManager {
         interactionManager.handleContainerInput(0, slot, 0, ContainerInput.PICKUP, player);
         interactionManager.handleContainerInput(0, CHESTPLATE_INDEX, 0, ContainerInput.PICKUP, player);
         interactionManager.handleContainerInput(0, slot, 0, ContainerInput.PICKUP, player);
-        player.connection.send(new ServerboundPlayerCommandPacket(player, ServerboundPlayerCommandPacket.Action.START_FALL_FLYING));
     }
 
     private static int getItemUID(ItemStack stack) {


### PR DESCRIPTION
fix #28 Bug: [BUG] Auto Equip Does Not Automatically Start Flight

Root cause: equipElytra() sent START_FALL_FLYING packet to server but never set the client-side FLAG_FALL_FLYING shared flag. Player.startFallFlying() only sets setSharedFlag(7,true) and does NOT send the network packet; in vanilla flow the packet is sent separately by LocalPlayer.aiStep() after tryToStartFallFlying() returns true. Since the mixin fires after tryToStartFallFlying() already returned false, the enclosing if-block is skipped and the packet is never sent.

Changes:
- ClientPlayerEntityMixin: After equipElytra(), do BOTH player.startFallFlying() (client flag) AND connection.send(START_FALL_FLYING) (server notification)
- ElytraManager.equipElytra(): Remove raw packet send — flight initiation is now the mixin's responsibility
- ElytraManager.swapChestplateSlot(): Remove raw packet send — this method is also called from equipChestplate() where sending START_FALL_FLYING is semantically wrong
