### PR TITLE
fix: check Elytra availability before auto-equip and takeoff

### DIFF
--- a/src/main/java/net/elytraautopilot/ElytraAutoPilot.java
+++ b/src/main/java/net/elytraautopilot/ElytraAutoPilot.java
@@ -494,7 +494,7 @@ public class ElytraAutoPilot implements ClientModInitializer {
 
     private static boolean canRestockElytra(LocalPlayer player) {
         var result = getElytraIndex(player);
-        return result != -1;
+        return result != -100;
     }
 
     private void computeVelocity() {

--- a/src/main/java/net/elytraautopilot/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/net/elytraautopilot/mixin/ClientPlayerEntityMixin.java
@@ -26,7 +26,8 @@ public class ClientPlayerEntityMixin {
         // Injects when the elytra should be deployed
         if (canGlide(player)) { // &&
             // [Future] Replace with an event that fires before elytra take off.
-            equipElytra(player);
+            if (!equipElytra(player))
+                return; // No Elytra available in inventory, abort takeoff
             // Set client-side flying flag AND send packet to server
             // (Player.startFallFlying only sets the client flag, does NOT send the packet)
             player.startFallFlying();


### PR DESCRIPTION
- ClientPlayerEntityMixin: check equipElytra() return value, abort if no Elytra in inventory
- ElytraAutoPilot: fix canRestockElytra() sentinel value from -1 to -100 (getElytraIndex returns -100 when no Elytra found)

Now mod will not try to equip elytra and start flight if there's no elytra in inventory.
I didn't full test when PR #32.😭 This is a fix.